### PR TITLE
Fix to override existing content-disposition header

### DIFF
--- a/playwright-example.js
+++ b/playwright-example.js
@@ -54,10 +54,18 @@ const { chromium } = require('playwright');
       // console.log(reqEvent.responseHeaders);
 
       // Adding 'content-disposition: attachment' header will tell the browser to download the file instead of opening it in using built-in viewer
-      responseHeaders.push({
-        name: 'content-disposition',
-        value: 'attachment',
-      });
+      const foundHeaderIndex = responseHeaders.findIndex(
+        (h) => h.name === "content-disposition"
+      );
+      const attachmentHeader = {
+        name: "content-disposition",
+        value: "attachment",
+      };
+      if (foundHeaderIndex) {
+        responseHeaders[foundHeaderIndex] = attachmentHeader;
+      } else {
+        responseHeaders.push(attachmentHeader);
+      }
 
       /*
         Fetch.getResponseBody

--- a/puppeteer-example.js
+++ b/puppeteer-example.js
@@ -51,10 +51,18 @@ const puppeteer = require('puppeteer');
       // console.log(reqEvent.responseHeaders);
 
       // Adding 'content-disposition: attachment' header will tell the browser to download the file instead of opening it in using built-in viewer
-      responseHeaders.push({
-        name: 'content-disposition',
-        value: 'attachment',
-      });
+      const foundHeaderIndex = responseHeaders.findIndex(
+        (h) => h.name === "content-disposition"
+      );
+      const attachmentHeader = {
+        name: "content-disposition",
+        value: "attachment",
+      };
+      if (foundHeaderIndex) {
+        responseHeaders[foundHeaderIndex] = attachmentHeader;
+      } else {
+        responseHeaders.push(attachmentHeader);
+      }
 
       /*
         Fetch.getResponseBody


### PR DESCRIPTION
Thanks for this repo!

Noticed one slight issue with a site I'm testing file downloads on. If the content-disposition header is already present when overriding, Chrome (r78 via puppeteer) does not honor the new content-disposition: attachment. This fix simply sets the attachment header if present, otherwise appends it.